### PR TITLE
Require plugins

### DIFF
--- a/build-fedora.sh
+++ b/build-fedora.sh
@@ -41,7 +41,7 @@ for cmd in 7z wget wrestool icotool convert npx rpm rpmbuild; do
     if ! check_command "$cmd"; then
         case "$cmd" in
             "7z")
-                DEPS_TO_INSTALL="$DEPS_TO_INSTALL p7zip"
+                DEPS_TO_INSTALL="$DEPS_TO_INSTALL p7zip-plugins"
                 ;;
             "wget")
                 DEPS_TO_INSTALL="$DEPS_TO_INSTALL wget"


### PR DESCRIPTION
Fix for:

✓ Download complete
📦 Extracting resources...
build-fedora.sh: line 128: 7z: command not found
❌ Failed to extract installer

Discovered using dnf:

```
# dnf provides 7z
Updating and loading repositories:
 Fedora 41 openh264 (From Cisco) - x86_64                                                                                           100% |   8.3 KiB/s |   8.6 KiB |  00m01s
 Fedora 41 - x86_64 - Updates                                                                                                       100% |   2.3 MiB/s |  24.7 MiB |  00m11s
 Fedora 41 - x86_64                                                                                                      100% |   2.2 MiB/s |  62.0 MiB |  00m28ssss20sm211ss
Repositories loaded.
p7zip-plugins-16.02-31.fc41.x86_64 : Additional plugins for p7zip
Repo         : fedora
Matched From : 
Filename     : /usr/bin/7z
```
