### PR TITLE
Update claude setup version to 0.8.0 and fix missing i18n resources

### DIFF
--- a/build-fedora.sh
+++ b/build-fedora.sh
@@ -87,7 +87,7 @@ if ! check_command "electron"; then
 fi
 
 # Extract version from the installer filename
-VERSION=$(basename "$CLAUDE_DOWNLOAD_URL" | grep -oP 'Claude-Setup-x64\.exe' | sed 's/Claude-Setup-x64\.exe/0.7.9/')
+VERSION=$(basename "$CLAUDE_DOWNLOAD_URL" | grep -oP 'Claude-Setup-x64\.exe' | sed 's/Claude-Setup-x64\.exe/0.8.0/')
 PACKAGE_NAME="claude-desktop"
 ARCHITECTURE="amd64"
 MAINTAINER="Claude Desktop Linux Maintainers"
@@ -228,6 +228,9 @@ mkdir -p app.asar.contents/resources
 cp ../lib/net45/resources/Tray* app.asar.contents/resources/
 
 # Repackage app.asar
+mkdir -p app.asar.contents/resources/i18n/
+cp ../lib/net45/resources/*.json app.asar.contents/resources/i18n/
+
 npx asar pack app.asar.contents app.asar
 
 # Create native module with keyboard constants


### PR DESCRIPTION
This pull request updates the Claude Desktop build script to use version 0.8.0 and fixes an issue where internationalization (i18n) resources were missing when starting the application.

## Changes Made
- Updated the version string in the build script from 0.7.9 to 0.8.0
- Added code to properly copy i18n resource files (JSON files) to the application package
- Created the necessary i18n directory structure in the resources folder

## Bug Fix
The application was previously missing internationalization resources at startup, which could cause display issues or error messages when running in non-English locales. This PR ensures all necessary i18n files are properly packaged with the application. Not sure if there were also missing with the previous version, I could not build 0.7.9 locally.

## Testing
- Verified the application builds correctly with version 0.8.0
- Confirmed the i18n resources are properly included in the final package
- Tested application startup to ensure no missing resource errors occur