### PR TITLE
Update distro check

### DIFF
--- a/build-fedora.sh
+++ b/build-fedora.sh
@@ -11,11 +11,7 @@ is_fedora_based() {
     fi
     
     if [ -f "/etc/os-release" ]; then
-        grep -qi "ID_LIKE.*fedora\|ID.*fedora" /etc/os-release && return 0
-    fi
-    
-    if command -v dnf >/dev/null 2>&1; then
-        return 0
+        grep -qi "fedora" /etc/os-release && return 0
     fi
     
     # Not a Fedora-based system


### PR DESCRIPTION
Add a check against os-release that's pretty permissive to try and catch edge-case versions like Nobara.

I've removed checking for dnf as it's too widely used (rhel, for example)