### PR TITLE
Add sqlite3 dependency

### DIFF
--- a/build-fedora.sh
+++ b/build-fedora.sh
@@ -81,9 +81,12 @@ echo "Checking dependencies..."
 DEPS_TO_INSTALL=""
 
 # Check system package dependencies
-for cmd in 7z wget wrestool icotool convert npx rpm rpmbuild; do
+for cmd in sqlite3 7z wget wrestool icotool convert npx rpm rpmbuild; do
     if ! check_command "$cmd"; then
         case "$cmd" in
+            "sqlite3")
+                DEPS_TO_INSTALL="$DEPS_TO_INSTALL sqlite3"
+                ;;
             "7z")
                 DEPS_TO_INSTALL="$DEPS_TO_INSTALL p7zip-plugins"
                 ;;


### PR DESCRIPTION
### Issue:
If the `sqlite3` package is missing on the target machine, the `build-fedora.sh` script fails to run any `npm` command. As a result, the `Electron` package is not installed, and the `claude-desktop` binary does not run.

### Fix:
add `sqlite3` to dependency list.

### How to reproduce issue:
Try to run this script on a machine where sqlite3 package is not installed.