### PR TITLE
fix icon issue with correct StartupWMCLass

### DIFF
--- a/build-fedora.sh
+++ b/build-fedora.sh
@@ -356,7 +356,7 @@ Type=Application
 Terminal=false
 Categories=Office;Utility;
 MimeType=x-scheme-handler/claude;
-StartupWMClass=claude
+StartupWMClass=Claude
 EOF
 
 # Create launcher script with Wayland flags and logging


### PR DESCRIPTION
currently launching on gnome shows the correct icon in the search but doesn't associate the correct icon with the open app. this is the because the startup WM class is "Claude" capitalized. changing this fixes it